### PR TITLE
GitButler Integration Commit

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,7 +60,6 @@ func streamPipelines(config *AppConfig, client *gitlab.Client, out chan<- Pipeli
 	}
 }
 
-
 func getGitlabClient(config *AppConfig) *gitlab.Client {
 	glab, err := gitlab.NewClient(
 		config.apiKey,


### PR DESCRIPTION
This is an integration commit for the virtual branches that GitButler is tracking.

Due to GitButler managing multiple virtual branches, you cannot switch back and forth between git branches and virtual branches easily. 

If you switch to another branch, GitButler will need to be reinitialized. If you commit on this branch, GitButler will throw it away.

Here are the branches that are currently applied:
 - Fix ticker duration (refs/gitbutler/fix-ticker-duration)
   - main.go
 - Remove empty line (refs/gitbutler/remove-empty-line) branch head: 744dbff74755cd4ad8d720bba7523ec1a97aa8fc
   - main.go

Your previous branch was: refs/heads/main

The sha for that commit was: e75d95b768e006838e7b0873903ca2fd270c09dc

For more information about what we're doing here, check out our docs: https://docs.gitbutler.com/features/virtual-branches/integration-branch